### PR TITLE
Add FAISS backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "transformers>=4.35,<4.42",
     "torch>=2.0,<2.3",
     "torchvision>=0.15,<0.19",
+    "faiss-cpu>=1.7.4",
     "pyyaml>=6.0",
     "codetiming>=1.4",
     "requests>=2.31",

--- a/src/inatinqperf/adaptors/__init__.py
+++ b/src/inatinqperf/adaptors/__init__.py
@@ -1,1 +1,8 @@
 """__init__.py for adaptors."""
+
+from inatinqperf.adaptors.faiss_backend import FaissFlat, FaissIVFPQ
+
+BACKENDS = {
+    "faiss.flat": FaissFlat,
+    "faiss.ivfpq": FaissIVFPQ,
+}

--- a/src/inatinqperf/adaptors/faiss_backend.py
+++ b/src/inatinqperf/adaptors/faiss_backend.py
@@ -1,0 +1,164 @@
+"""FAISS vector database backend adaptor."""
+
+from collections.abc import Sequence
+
+import faiss
+import numpy as np
+from loguru import logger
+
+from inatinqperf.adaptors.base import VectorBackend
+
+# TODO(Varun): Use Metric enum instead of strings
+
+
+class FaissFlat(VectorBackend):
+    """FAISS Flat index backend."""
+
+    def __init__(self, dim: int, metric: str = "ip", **params) -> None:  # noqa: ARG002
+        """Initialize FAISS Flat index."""
+        super().__init__()
+
+        self.dim = dim
+        self.metric = metric.lower()
+        base = faiss.IndexFlatIP(dim) if self.metric in ("ip", "cosine") else faiss.IndexFlatL2(dim)
+        self.index = faiss.IndexIDMap2(base)
+
+    def train(self, x_train: np.ndarray) -> None:
+        """Train the index with given vectors. No-op for Flat index."""
+
+    def upsert(self, ids: np.ndarray, x: np.ndarray) -> None:
+        """Upsert vectors with given IDs."""
+        self.index.remove_ids(faiss.IDSelectorArray(ids.astype("int64")))
+        self.index.add_with_ids(x.astype("float32"), ids.astype("int64"))
+
+    def delete(self, ids: Sequence[int]) -> None:
+        """Delete vectors with given IDs."""
+        arr = np.asarray(list(ids), dtype="int64")
+        self.index.remove_ids(faiss.IDSelectorArray(arr))
+
+    def search(self, q: np.ndarray, topk: int, **kwargs) -> tuple[np.ndarray, np.ndarray]:
+        """Search for top-k nearest neighbors."""
+        kwargs.pop("nprobe", None)  # not used
+        return self.index.search(q.astype("float32"), topk)
+
+    def stats(self) -> dict[str, object]:
+        """Return index statistics."""
+        return {"ntotal": int(self.index.ntotal), "kind": "flat", "metric": self.metric}
+
+    def drop(self) -> None:
+        """Drop the index."""
+        self.index = None
+
+
+def _unwrap_to_ivf(base: faiss.Index) -> faiss.Index | None:
+    """Return the IVF index inside a composite FAISS index, or None if not found.
+
+    Works across FAISS builds with/without extract_index_ivf.
+    """
+    # Try the official helper first
+    if hasattr(faiss, "extract_index_ivf"):
+        try:
+            ivf = faiss.extract_index_ivf(base)
+            if ivf is not None:
+                return ivf
+        except Exception:
+            logger.warning("[FAISS] Warning: extract_index_ivf failed")
+
+    # Fallback: walk .index fields until we find .nlist
+    node = base
+    visited = 0
+    five = 5
+    while node is not None and visited < five:
+        if hasattr(node, "nlist"):  # IVF layer
+            return node
+        node = getattr(node, "index", None)
+        visited += 1
+    return None
+
+
+class FaissIVFPQ(VectorBackend):
+    """FAISS IVF-PQ index backend."""
+
+    def __init__(self, dim: int, metric: str = "ip", **params) -> None:
+        """Initialize FAISS IVF-PQ index."""
+        super().__init__()
+
+        self.dim = dim
+        self.metric = metric.lower()
+        nlist = int(params.get("nlist", 32768))
+        self.m = int(params.get("m", 64))
+        self.nbits = int(params.get("nbits", 8))
+        self.nprobe = int(params.get("nprobe", 32))
+
+        # Build a robust composite index via index_factory
+        desc = f"OPQ{self.m},IVF{nlist},PQ{self.m}x{self.nbits}"
+        metric_type = faiss.METRIC_INNER_PRODUCT if self.metric in ("ip", "cosine") else faiss.METRIC_L2
+        base = faiss.index_factory(dim, desc, metric_type)
+        self.index = faiss.IndexIDMap2(base)
+
+    def train(self, x_train: np.ndarray) -> None:
+        """Train the index with given vectors."""
+        x_train = x_train.astype("float32", copy=False)
+        n = int(x_train.shape[0])
+
+        # If dataset is smaller than nlist, rebuild with reduced nlist
+        ivf = _unwrap_to_ivf(self.index.index)
+        if ivf is not None and hasattr(ivf, "nlist"):
+            current_nlist = int(ivf.nlist)
+            effective_nlist = max(1, min(current_nlist, n))
+            if effective_nlist != current_nlist:
+                # Recreate with smaller nlist to avoid training failures
+                self.init(
+                    self.dim,
+                    self.metric,
+                    nlist=effective_nlist,
+                    m=self.m,
+                    nbits=self.nbits,
+                    nprobe=self.nprobe,
+                )
+                ivf = _unwrap_to_ivf(self.index.index)
+
+        # Train if needed
+        if self.index is not None and not self.index.is_trained:
+            self.index.train(x_train)
+
+        # Set nprobe (if we have IVF)
+        ivf = _unwrap_to_ivf(self.index.index)
+        if ivf is not None and hasattr(ivf, "nprobe"):
+            # Clamp nprobe reasonably based on nlist if available
+            nlist = int(getattr(ivf, "nlist", max(1, self.nprobe)))
+            ivf.nprobe = min(self.nprobe, max(1, nlist))
+
+    def upsert(self, ids: np.ndarray, x: np.ndarray) -> None:
+        """Upsert vectors with given IDs."""
+        self.index.remove_ids(faiss.IDSelectorArray(ids.astype("int64")))
+        self.index.add_with_ids(x.astype("float32"), ids.astype("int64"))
+
+    def delete(self, ids: Sequence[int]) -> None:
+        """Delete vectors with given IDs."""
+        arr = np.asarray(list(ids), dtype="int64")
+        self.index.remove_ids(faiss.IDSelectorArray(arr))
+
+    def search(self, q: np.ndarray, topk: int, **kwargs) -> tuple[np.ndarray, np.ndarray]:
+        """Search for top-k nearest neighbors. Supports runtime nprobe override."""
+        q = q.astype("float32", copy=False)
+        # Runtime override for nprobe
+        ivf = _unwrap_to_ivf(self.index.index)
+        if ivf is not None and hasattr(ivf, "nprobe"):
+            ivf.nprobe = int(kwargs.get("nprobe", self.nprobe))
+        return self.index.search(q, topk)
+
+    def stats(self) -> dict[str, object]:
+        """Return index statistics."""
+        ivf = _unwrap_to_ivf(self.index.index) if self.index is not None else None
+        return {
+            "ntotal": int(self.index.ntotal) if self.index is not None else 0,
+            "kind": "ivfpq",
+            "metric": self.metric,
+            "nlist": int(getattr(ivf, "nlist", -1)) if ivf is not None else None,
+            "nprobe": int(getattr(ivf, "nprobe", -1)) if ivf is not None else None,
+        }
+
+    def drop(self) -> None:
+        """Drop the index."""
+        self.index = None

--- a/src/inatinqperf/utils/dataio.py
+++ b/src/inatinqperf/utils/dataio.py
@@ -1,7 +1,7 @@
 """Utilities for data I/O operations."""
 
-from collections.abc import Sequence
 import csv
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np

--- a/src/inatinqperf/utils/embed.py
+++ b/src/inatinqperf/utils/embed.py
@@ -1,6 +1,8 @@
 """Utilities for embedding images and text using CLIP models."""
 
 from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -8,8 +10,6 @@ from datasets import Dataset, Features, Value, load_from_disk
 from datasets import Sequence as HFSequence
 from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
-from pathlib import Path
-from dataclasses import dataclass
 
 _EMBED_MATRIX_NDIM = 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+# tests/conftest.py
+"""Pytest configuration for shared test setup."""
+
+import importlib
+import os
+
+# Keep thread counts low and avoid at-fork init issues that can trip FAISS/Torch on macOS
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("OMP_WAIT_POLICY", "PASSIVE")
+os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
+os.environ.setdefault("FAISS_DISABLE_GPU", "1")
+
+
+def pytest_sessionstart(session):
+    """Clamp FAISS OMP threads early in the session."""
+    try:
+        import faiss  # type: ignore
+
+        if hasattr(faiss, "omp_set_num_threads"):
+            faiss.omp_set_num_threads(1)
+    except Exception:
+        # It's okay if FAISS isn't importable here.
+        pass

--- a/tests/test_faiss_backend.py
+++ b/tests/test_faiss_backend.py
@@ -1,0 +1,269 @@
+import contextlib
+import io
+
+import numpy as np
+import pytest
+
+from inatinqperf.adaptors import faiss_backend
+from inatinqperf.adaptors.faiss_backend import FaissFlat, FaissIVFPQ
+
+
+@pytest.fixture
+def small_data():
+    X = np.array(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [-1.0, 0.0],
+        ],
+        dtype="float32",
+    )
+    ids = np.array([100, 101, 102, 103], dtype="int64")
+    return ids, X
+
+
+@pytest.fixture
+def ivfpq_trainset():
+    """Large training set so IVF-PQ can train without FAISS clustering warnings."""
+    rng = np.random.default_rng(42)
+    X = rng.standard_normal((10240, 2)).astype("float32")  # >= 9984
+    ids = np.arange(1000, 1000 + X.shape[0], dtype="int64")
+    return ids, X
+
+
+@pytest.mark.parametrize("metric", ["ip", "l2"])
+def test_faiss_flat_lifecycle(metric, small_data):
+    ids, X = small_data
+    be = FaissFlat(dim=2, metric=metric)
+
+    be.upsert(ids, X)
+    st = be.stats()
+    assert st["ntotal"] == len(ids)
+
+    Q = np.array([[1.0, 0.0], [0.5, 0.5]], dtype="float32")
+    D, I = be.search(Q, topk=2)
+
+    # shape checks
+    assert D.shape == (2, 2)
+    assert I.shape == (2, 2)
+
+    # nearest to [1,0] should include id 100
+    assert 100 in I[0]
+
+    # delete some ids
+    be.delete([101, 103])
+    assert be.stats()["ntotal"] == 2
+
+    # drop releases index (idempotent)
+    be.drop()
+    be.drop()
+    assert getattr(be, "index", None) is None
+
+
+def test_faiss_ivfpq_train_and_search_with_large_training(ivfpq_trainset, small_data):
+    _, X_train = ivfpq_trainset
+    ids, X = small_data
+
+    # Use fewer PQ centroids (nbits=4 -> 16) so 300 training points suffice without warnings
+    be = FaissIVFPQ(dim=2, metric="ip", nlist=2, m=1, nbits=4, nprobe=2)
+
+    # training on sufficient dataset (silence FAISS native stderr warnings)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(X_train)
+
+    # upsert a small, known set for deterministic checks
+    be.upsert(ids, X)
+
+    s = be.stats()
+    assert s["kind"] == "ivfpq"
+    assert "nlist" in s
+    assert "nprobe" in s
+
+    Q = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+    D, I = be.search(Q, topk=2)
+
+    # shapes
+    assert D.shape == (2, 2)
+    assert I.shape == (2, 2)
+    # ids returned should come from our set (since they are much closer than random train points)
+    assert set(I.flatten()).issubset(set(ids))
+
+    # delete works and stats update
+    be.delete([100])
+    assert be.stats()["ntotal"] == len(ids) - 1
+
+    # drop releases resources
+    be.drop()
+    assert getattr(be, "index", None) is None
+
+
+def test_faiss_ivfpq_l2_metric_delete_and_drop(ivfpq_trainset, small_data):
+    _, X_train = ivfpq_trainset
+    ids, X = small_data
+
+    # Fewer centroids to prevent FAISS training warnings
+    be = FaissIVFPQ(dim=2, metric="l2", nlist=2, m=1, nbits=4, nprobe=2)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(X_train)
+    be.upsert(ids, X)
+
+    # Search with L2 metric; still expect small_data ids to appear
+    Q = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+    # Increase nprobe to improve recall; ANN may otherwise return fewer than topk hits (filled with -1)
+    D, I = be.search(Q, topk=3, nprobe=64)
+    assert D.shape == (2, 3)
+    assert I.shape == (2, 3)
+    valid = I[I >= 0]  # filter out FAISS "no result" slots
+    assert set(valid.flatten()).issubset(set(ids))
+
+    # Deleting non-existent id should not raise
+    be.delete([999])
+
+    # Delete existing and verify
+    be.delete([101])
+    assert be.stats()["ntotal"] == len(ids) - 1
+
+    # Drop twice to exercise idempotency
+    be.drop()
+    be.drop()
+    assert getattr(be, "index", None) is None
+
+
+def test_faiss_ivfpq_runtime_nprobe_override_and_upsert_replace(ivfpq_trainset, small_data):
+    """Cover runtime nprobe override branch and upsert replacement semantics for IVFPQ."""
+    _, X_train = ivfpq_trainset
+    ids, X = small_data
+
+    be = FaissIVFPQ(dim=2, metric="ip", nlist=2, m=1, nbits=4, nprobe=1)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(X_train)
+
+    # First insert
+    be.upsert(ids, X)
+    nt1 = be.stats()["ntotal"]
+
+    # Upsert same ids with slightly shifted vectors (replacement semantics)
+    be.upsert(ids, X + 0.01)
+    nt2 = be.stats()["ntotal"]
+    assert nt2 == nt1  # replaced, not duplicated
+
+    # Force a very small and a larger nprobe to exercise the branch
+    Q = np.array([[1.0, 0.0]], dtype="float32")
+    D1, I1 = be.search(Q, topk=3, nprobe=1)
+    D2, I2 = be.search(Q, topk=3, nprobe=64)
+
+    assert D1.shape == D2.shape == (1, 3)
+    assert I1.shape == I2.shape == (1, 3)
+
+    be.drop()
+
+
+def test_faiss_flat_topk_greater_than_ntotal_and_idempotent_delete(small_data):
+    """Cover branch where topk > ntotal and deleting non-existent IDs is a no-op."""
+    ids, X = small_data
+    be = FaissFlat(dim=2, metric="ip")
+    be.upsert(ids, X)
+
+    Q = np.array([[0.2, 0.9]], dtype="float32")
+    # Ask for more neighbors than we have to ensure code handles it
+    D, I = be.search(Q, topk=10)
+    assert D.shape == (1, 10)
+    assert I.shape == (1, 10)
+
+    # Deleting IDs that do not exist should not raise and should keep counts stable
+    nt_before = be.stats()["ntotal"]
+    be.delete([999, 1000])
+    assert be.stats()["ntotal"] == nt_before
+
+    be.drop()
+    be.drop()
+    assert getattr(be, "index", None) is None
+
+
+def test_metric_mapping_and_unwrap_real_index(ivfpq_trainset, small_data):
+    # Build a real IVFPQ index and ensure unwrap hits the IVF layer
+    be = FaissIVFPQ(dim=2, metric="ip", nlist=2, m=1, nbits=4, nprobe=2)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(ivfpq_trainset[1])
+    ivf = faiss_backend._unwrap_to_ivf(be.index.index)
+    assert ivf is not None and hasattr(ivf, "nlist")
+    be.drop()
+
+
+def test_faiss_ivfpq_cosine_metric_and_topk_gt_ntotal(ivfpq_trainset, small_data):
+    # Cosine path should map to inner-product internally
+    ids, X = small_data
+    be = FaissIVFPQ(dim=2, metric="cosine", nlist=2, m=1, nbits=4, nprobe=2)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(ivfpq_trainset[1])
+    be.upsert(ids, X)
+
+    Q = np.array([[1.0, 0.0]], dtype="float32")
+    # Ask for more neighbors than exist; FAISS may pad with -1
+    D, I = be.search(Q, topk=10, nprobe=64)
+    assert D.shape == (1, 10) and I.shape == (1, 10)
+    valid = I[I >= 0]
+    assert set(valid.flatten()).issubset(set(ids))
+    be.drop()
+
+
+def test_faiss_ivfpq_empty_delete_noop(ivfpq_trainset, small_data):
+    ids, X = small_data
+    be = FaissIVFPQ(dim=2, metric="ip", nlist=2, m=1, nbits=4, nprobe=2)
+    _buf = io.StringIO()
+    with contextlib.redirect_stderr(_buf):
+        be.train(ivfpq_trainset[1])
+    be.upsert(ids, X)
+
+    # Empty delete should be a no-op
+    be.delete([])
+    assert be.stats()["ntotal"] == len(ids)
+    be.drop()
+
+
+def test_unwrap_fallback_dummy_chain():
+    """Exercise the fallback path in _unwrap_to_ivf by walking .index chain without faiss.extract_index_ivf."""
+
+    class Leaf:
+        def __init__(self):
+            self.nlist = 5
+
+    class Wrapper:
+        def __init__(self, inner):
+            self.index = inner
+
+    base = Wrapper(Wrapper(Leaf()))
+    out = faiss_backend._unwrap_to_ivf(base)
+    assert out is not None and hasattr(out, "nlist") and out.nlist == 5
+
+
+## The following test needs to be debugged
+# def test_faiss_ivfpq_reduces_nlist_and_clamps_nprobe(small_data):
+#     """Cover train() branch that rebuilds with smaller nlist and clamps nprobe to nlist."""
+#     ids, X = small_data
+#     # Start with large nlist, tiny PQ (nbits=2, m=1) so training with small set succeeds and triggers reduce.
+#     be = FaissIVFPQ(dim=2, metric="ip", nlist=64, m=1, nbits=2)  # nprobe defaults to 32
+#     _, X_train = ivfpq_trainset  # 10,240 x 2
+#     #X_train = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.1], [0.2, 0.3], [0.9, 0.2], [0.1, 0.8], [0.3, 0.4], [0.7, 0.6]], dtype="float32")
+#     _buf = io.StringIO()
+#     with contextlib.redirect_stderr(_buf):
+#         be.train(X_train)
+#     s = be.stats()
+#     assert s["kind"] == "ivfpq"
+#     # nlist reduced to <= number of training points
+#     assert s["nlist"] is None or int(s["nlist"]) <= X_train.shape[0]
+#     # nprobe clamped to nlist (default nprobe is 32, so expect <= nlist)
+#     if s.get("nlist") is not None and s.get("nprobe") is not None:
+#         assert int(s["nprobe"]) <= int(s["nlist"])
+
+#     # Upsert and search still function
+#     be.upsert(ids, X)
+#     D, I = be.search(np.array([[1.0, 0.0]], dtype="float32"), topk=2)
+#     assert D.shape == (1, 2) and I.shape == (1, 2)
+#     be.drop()

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,5 +1,4 @@
 # tests/test_profiler.py
-
 import json
 import time
 from pathlib import Path

--- a/uv.lock
+++ b/uv.lock
@@ -422,6 +422,65 @@ wheels = [
 ]
 
 [[package]]
+name = "faiss-cpu"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/80/bb75a7ed6e824dea452a24d3434a72ed799324a688b10b047d441d270185/faiss_cpu-1.12.0.tar.gz", hash = "sha256:2f87cbcd603f3ed464ebceb857971fdebc318de938566c9ae2b82beda8e953c0", size = 69292, upload-time = "2025-08-13T06:07:26.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/3b/42aa7332c2e432fc3af3a26cc49ca8a3ecd23d13bb790e61c1e54a4d16cb/faiss_cpu-1.12.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:be96f9290edd13d56fb3c69b8dd6be487552b4401f2e95b437cabf5309c424ad", size = 8006082, upload-time = "2025-08-13T06:05:33.131Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ab/9959c2d9c3a511a5dbfa4e2e2a1d0bdcad5929d410b3abe87bbed74dcb9b/faiss_cpu-1.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0834c547c39d5e5d0b769c90ac5d5ca42e00bcdbba491f3440d2d458058b19d6", size = 3360138, upload-time = "2025-08-13T06:05:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b9/7456f89effe93b7693c7e39cd365065e27aa31794442510c44ad8cce6c4c/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a40830a16d8718b14a462e1a1efaa26660eb3bb8ada22e0712a6ac181092750e", size = 3825459, upload-time = "2025-08-13T06:05:36.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0f/02d5d2ae8b53e5629cb03fbd871bbbfbbd647ffc3d09393b34f6347072d7/faiss_cpu-1.12.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7f8732796e3f730556e99327861066ead0ae7e66b5cbf6c0f217be48074e41e", size = 31425823, upload-time = "2025-08-13T06:05:38.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/a9fcb0b82727ab2d5509caa7637e5d345c710502f68c7a7e90dd212654ad/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ded5063e13c3bb6b1b463827f838ae45a0aea4c9aeaf6c938e7e87f3f6ea4126", size = 9751939, upload-time = "2025-08-13T06:05:41.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/25/7efcb5856f9df4c003716687c4604bb5cfc44819539b79d60e302018962b/faiss_cpu-1.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8e74e71249165757a12fb02feee67ea95df542bcafa21b449fbd2ed0c31b48b4", size = 24160951, upload-time = "2025-08-13T06:05:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/1f1cc444708b426b42ec52f01c735d91cb9775fe55cf3d2c64b9a6fd8792/faiss_cpu-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:d04d1cae2a9b66083cd8f48ff391731d81e0a1fdf67ab5c33ae10b3a22a0caae", size = 18169601, upload-time = "2025-08-13T06:05:46.558Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/83fed257ea410c2e691374f04ac914d5f9414f04a9c7a266bdfbb999eb16/faiss_cpu-1.12.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fbb63595c7ad43c0d9caaf4d554a38a30ea4edda5e7c3ed38845562776992ba9", size = 8006079, upload-time = "2025-08-13T06:05:48.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/07/80c248db87ef2e753ad390fca3b0d7dd6092079e904f35b248c7064e791e/faiss_cpu-1.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83e74cbde6fa5caceec5bc103c82053d50fde163e3ceabaa58c91508e984142b", size = 3360138, upload-time = "2025-08-13T06:05:50.873Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/22/73bd9ed7b11cd14eb0da6e2f2eae763306abaad1b25a5808da8b1fc07665/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6155a5138604b702a32f8f0a63948a539eb7468898554a9911f9ab8c899284fb", size = 3825466, upload-time = "2025-08-13T06:05:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7f/e1a21337b3cba24b953c760696e3b188a533d724440e050fd60a3c1aa919/faiss_cpu-1.12.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bf4b5f0e9b6bb5a566b1a31e84a93b283f26c2b0155fb2eb5970c32a540a906", size = 31425626, upload-time = "2025-08-13T06:05:54.155Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/f352cf8400f414e6a31385ef12d43d11aac8beb11d573a2fd00ec44b8cb7/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60a535b79d3d6225c7c21d7277fb0c6fde80c46a9c1e33632b1b293c1d177f30", size = 9751949, upload-time = "2025-08-13T06:05:56.369Z" },
+    { url = "https://files.pythonhosted.org/packages/05/50/a122e3076d7fd95cbe9a0cdf0fc796836f1e4fd399b418c6ba8533c75770/faiss_cpu-1.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1b243468a24564f85a41166f2ca4c92f8f6755da096ffbdcf551675ca739c5", size = 24161021, upload-time = "2025-08-13T06:05:58.776Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9f/3344f6fe69f6fbfb19dec298b4dda3d47a87dc31e418911fdcc3a3ace013/faiss_cpu-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:84510079a2efe954e6b89fe5e62f23a98c1ef999756565e056f95f835ff43c5e", size = 18169278, upload-time = "2025-08-13T06:06:01.44Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b1/37d532292c1b3dab690636947a532d3797741b09f2dfb9cb558ffeaff34b/faiss_cpu-1.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:2283f1014f7f86dd56b53bf0ea0d7f848eb4c9c6704b8f4f99a0af02e994e479", size = 8007093, upload-time = "2025-08-13T06:06:03.904Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/602ed184d35742eb240cbfea237bd214f2ae7f01cb369c39f4dff392f7c9/faiss_cpu-1.12.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9b54990fcbcf90e37393909d4033520237194263c93ab6dbfae0616ef9af242b", size = 8034413, upload-time = "2025-08-13T06:06:05.564Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/f84c3d0e022cdeb73ff8406a6834a7698829fa242eb8590ddf8a0b09357f/faiss_cpu-1.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a5f5bca7e1a3e0a98480d1e2748fc86d12c28d506173e460e6746886ff0e08de", size = 3362034, upload-time = "2025-08-13T06:06:07.091Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a4ba4d285ea4f9b0824bf31ebded3171da08bfcf5376f4771cc5481f72cd/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:016e391f49933875b8d60d47f282f2e93d8ea9f9ffbda82467aa771b11a237db", size = 3834319, upload-time = "2025-08-13T06:06:08.86Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c9/be4e52fd96be601fefb313c26e1259ac2e6b556fb08cc392db641baba8c7/faiss_cpu-1.12.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2e4963c7188f57cfba248f09ebd8a14c76b5ffb87382603ccd4576f2da39d74", size = 31421585, upload-time = "2025-08-13T06:06:10.643Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/aa/12c6723ce30df721a6bace21398559c0367c5418c04139babc2d26d8d158/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:88bfe134f8c7cd2dda7df34f2619448906624962c8207efdd6eb1647e2f5338b", size = 9762449, upload-time = "2025-08-13T06:06:13.373Z" },
+    { url = "https://files.pythonhosted.org/packages/67/15/ed2c9de47c3ebae980d6938f0ec12d739231438958bc5ab2d636b272d913/faiss_cpu-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9243ee4c224a0d74419040503f22bf067462a040281bf6f3f107ab205c97d438", size = 24156525, upload-time = "2025-08-13T06:06:15.307Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/6911de6b8fdcfa76144680c2195df6ce7e0cc920a8be8c5bbd2dfe5e3c37/faiss_cpu-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:6b8012353d50d9bc81bcfe35b226d0e5bfad345fdebe0da31848395ebc83816d", size = 18169636, upload-time = "2025-08-13T06:06:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/69/d2b0f434b0ae35344280346b58d2b9a251609333424f3289c54506e60c51/faiss_cpu-1.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:8b4f5b18cbe335322a51d2785bb044036609c35bfac5915bff95eadc10e89ef1", size = 8012423, upload-time = "2025-08-13T06:06:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4e/6be5fbd2ceccd87b168c64edeefa469cd11f095bb63b16a61a29296b0fdb/faiss_cpu-1.12.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c9c79b5f28dcf9b2e2557ce51b938b21b7a9d508e008dc1ffea7b8249e7bd443", size = 8034409, upload-time = "2025-08-13T06:06:22.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f0/658012a91a690d82f3587fd8e56ea1d9b9698c31970929a9dba17edd211e/faiss_cpu-1.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0db6485bc9f32b69aaccf9ad520782371a79904dcfe20b6da5cbfd61a712e85f", size = 3362034, upload-time = "2025-08-13T06:06:24.052Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8b/9b355309d448e1a737fac31d45e9b2484ffb0f04f10fba3b544efe6661e4/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6db5532831791d7bac089fc580e741e99869122946bb6a5f120016c83b95d10", size = 3834324, upload-time = "2025-08-13T06:06:25.506Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/d229f6cdb9cbe03020499d69c4b431b705aa19a55aa0fe698c98022b2fef/faiss_cpu-1.12.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d57ed7aac048b18809af70350c31acc0fb9f00e6c03b6ed1651fd58b174882d", size = 31421590, upload-time = "2025-08-13T06:06:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/26/19/80289ba008f14c95fbb6e94617ea9884e421ca745864fe6b8b90e1c3fc94/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:26c29290e7d1c5938e5886594dc0a2272b30728351ca5f855d4ae30704d5a6cc", size = 9762452, upload-time = "2025-08-13T06:06:30.237Z" },
+    { url = "https://files.pythonhosted.org/packages/af/e7/6cc03ead5e19275e34992419e2b7d107d0295390ccf589636ff26adb41e2/faiss_cpu-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b43d0c295e93a8e5f1dd30325caaf34d4ecb51f1e3d461c7b0e71bff3a8944b", size = 24156530, upload-time = "2025-08-13T06:06:32.23Z" },
+    { url = "https://files.pythonhosted.org/packages/34/90/438865fe737d65e7348680dadf3b2983bdcef7e5b7e852000e74c50a9933/faiss_cpu-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:a7c6156f1309bb969480280906e8865c3c4378eebb0f840c55c924bf06efd8d3", size = 18169604, upload-time = "2025-08-13T06:06:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/76/69/40a1d8d781a70d33c57ef1b4b777486761dd1c502a86d27e90ef6aa8a9f9/faiss_cpu-1.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b5fac98a350774a98b904f7a7c6689eb5cf0a593d63c552e705a80c55636d15", size = 8012523, upload-time = "2025-08-13T06:06:37.24Z" },
+    { url = "https://files.pythonhosted.org/packages/12/35/01a4a7c179d67bee0d8a027b95c3eae19cb354ae69ef2bc50ac3b93bc853/faiss_cpu-1.12.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:ff7db774968210d08cd0331287f3f66a6ffef955a7aa9a7fcd3eb4432a4ce5f5", size = 8036142, upload-time = "2025-08-13T06:06:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/08/23/bac2859490096608c9d527f3041b44c2e43f8df0d4aadd53a4cc5ce678ac/faiss_cpu-1.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:220b5bb5439c64e417b35f9ade4c7dc3bf7df683d6123901ba84d6d764ecd486", size = 3363747, upload-time = "2025-08-13T06:06:40.73Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/e18023e1f43a18ec593adcd69d356f1fa94bde20344e38334d5985e5c5cc/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:693d0bf16f79e8d16a1baaeda459f3375f37da0354e97dc032806b48a2a54151", size = 3835232, upload-time = "2025-08-13T06:06:42.172Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/1c1fea423d3f550f44c5ec3f14d8400919b49c285c3bd146687c63e40186/faiss_cpu-1.12.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcc6587dee21e17430fb49ddc5200625d6f5e1de2bdf436f14827bad4ca78d19", size = 31432677, upload-time = "2025-08-13T06:06:44.348Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d2/3483e92a02f30e2d8491a256f470f54b7f5483266dfe09126d28741d31ec/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b80e5965f001822cc99ec65c715169af1b70bdae72eccd573520a2dec485b3ee", size = 9765504, upload-time = "2025-08-13T06:06:46.567Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2f/d97792211a9bd84b8d6b1dcaa1dcd69ac11e026c6ef19c641b6a87e31025/faiss_cpu-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98279f1b4876ef9902695a329b81a99002782ab6e26def472022009df6f1ac68", size = 24169930, upload-time = "2025-08-13T06:06:48.916Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b707ca4d88af472509a053c39d3cced53efd19d096b8dff2fadc18c4b82d/faiss_cpu-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:11670337f9f5ee9ff3490e30683eea80add060c300cf6f6cb0e8faf3155fd20e", size = 18475400, upload-time = "2025-08-13T06:06:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/77/11/42e41ddebde4dfe77e36e92d0110b4f733c8640883abffde54f802482deb/faiss_cpu-1.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:7ac1c8b53609b5c722ab60f1749260a7cb3c72fdfb720a0e3033067e73591da5", size = 8281229, upload-time = "2025-08-13T06:06:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/8ae5bbeabe70eb673c37fc7c77e2e476746331afb6654b2df97d8b6d380d/faiss_cpu-1.12.0-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:110b21b7bb4c93c4f1a5eb2ffb8ef99dcdb4725f8ab2e5cd161324e4d981f204", size = 8087247, upload-time = "2025-08-13T06:06:55.407Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/df/b3d79098860b67b126da351788c04ac243c29718dadc4a678a6f5e7209c0/faiss_cpu-1.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:82eb5515ce72be9a43f4cf74447a0d090e014231981df91aff7251204b506fbf", size = 3411043, upload-time = "2025-08-13T06:06:56.983Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/2f/b1a2a03dd3cce22ff9fc434aa3c7390125087260c1d1349311da36eaa432/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:754eef89cdf2b35643df6b0923a5a098bdfecf63b5f4bd86c385042ee511b287", size = 3801789, upload-time = "2025-08-13T06:06:58.688Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a8/16ad0c6a966e93d04bfd5248d2be1d8b5849842b0e2611c5ecd26fcaf036/faiss_cpu-1.12.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7285c71c8f5e9c58b55175f5f74c78c518c52c421a88a430263f34e3e31f719c", size = 31231388, upload-time = "2025-08-13T06:07:00.55Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/9c16eca0b8f8b13c32c47a5e4ff7a4bc0ca3e7d263140312088811230871/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:84a50d7a2f711f79cc8b65aa28956dba6435e47b71a38b2daea44c94c9b8e458", size = 9737605, upload-time = "2025-08-13T06:07:03.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4a/2c2d615078c9d816a836fb893aaef551ad152f2eb00bc258698273c240c0/faiss_cpu-1.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f3e0a14e4edec6a3959a9f51afccb89e863138f184ff2cc24c13f9ad788740b", size = 23922880, upload-time = "2025-08-13T06:07:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/30/aa/99b8402a4dac678794f13f8f4f29d666c2ef0a91594418147f47034ebc81/faiss_cpu-1.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8b3239cc371df6826ac43c62ac04eec7cc497bedb43f681fcd8ea494f520ddbb", size = 18750661, upload-time = "2025-08-13T06:07:07.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a2/b546e9a20ba157eb2fbe141289f1752f157ee6d932899f4853df4ded6d4b/faiss_cpu-1.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58b23456db725ee1bd605a6135d2ef55b2ac3e0b6fe873fd99a909e8ef4bd0ff", size = 8302032, upload-time = "2025-08-13T06:07:09.602Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -621,6 +680,7 @@ source = { editable = "." }
 dependencies = [
     { name = "codetiming" },
     { name = "datasets" },
+    { name = "faiss-cpu" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "pandas" },
@@ -651,6 +711,7 @@ dev = [
 requires-dist = [
     { name = "codetiming", specifier = ">=1.4" },
     { name = "datasets", specifier = ">=2.14,<3.0" },
+    { name = "faiss-cpu", specifier = ">=1.7.4" },
     { name = "huggingface-hub", specifier = ">=0.23" },
     { name = "numpy", specifier = ">=1.23,<2.0" },
     { name = "pandas", specifier = ">=1.5,<2.3" },


### PR DESCRIPTION
## :pencil: Description
Add FAISS as the first vector database backend.

There are a lot of improvements I intend to make in a follow-up PR.
1. Rename `VectorBackend` to `VectorDatabase`.
2. Replace `train` and `drop` with `train_index` and `drop_index` to better disambiguate from training data and the full database drop.
3. Refactor to reduce code duplication.
4. Others that I might find along the way.
